### PR TITLE
Update PIP requirements versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-black==19.10b0
-eth-brownie>=1.11.0,<2.0.0
-flake8==3.7.9
-isort==4.3.21
-pre-commit==2.4.0
-tox==3.15.1
+black==21.11b1
+eth-brownie>=1.17.2,<2.0.0
+flake8==4.0.1
+isort==5.10.1
+pre-commit==2.17.0
+tox==3.24.5


### PR DESCRIPTION
The versions of some PIP packages used until now are deprecated.

Also, updating the version of black package allows the use of more
recent versions of eth-brownie. This fixes the error on Github Actions
about remapping, since older versions of eth-brownie doesn't support it.