### PR TITLE
Delete redundant condition of require

### DIFF
--- a/contracts/matic/SubscriptionManager.sol
+++ b/contracts/matic/SubscriptionManager.sol
@@ -62,7 +62,7 @@ contract SubscriptionManager is Initializable, AccessControlUpgradeable {
         );
         uint32 duration = _endTimestamp - _startTimestamp;
         require(
-            duration > 0 && _size > 0 &&
+            _size > 0 &&
             msg.value == feeRate * _size * uint32(duration)
         );
 


### PR DESCRIPTION
This condition is implicitly checked in the first require of the
function: condition _startTimestamp < _endTimestamp implies that
duration will be greater than 0.

Avoiding this check becomes in a gas saving of 0.07%.